### PR TITLE
[FIX] add missing `Loader.isModLoaded("thaumicenergistics")`

### DIFF
--- a/src/main/java/com/github/aeddddd/ae2enhanced/registry/ModContent.java
+++ b/src/main/java/com/github/aeddddd/ae2enhanced/registry/ModContent.java
@@ -28,7 +28,7 @@ public final class ModContent {
         if (Loader.isModLoaded("mekanism") && Loader.isModLoaded("mekeng")) {
             FakeGases.init();
         }
-        if (Loader.isModLoaded("thaumcraft")) {
+        if (Loader.isModLoaded("thaumcraft") && Loader.isModLoaded("thaumicenergistics")) {
             FakeEssentias.init();
         }
         if (Loader.isModLoaded("botania")) {


### PR DESCRIPTION
In the `ModContent` class, within the `init` method, the check for the `Thaumic Energistics` mod having been loaded was omitted, which meant that if the mod was missing, a crash occurred with a ‘NoClassDefFound’ error.